### PR TITLE
Update example.py

### DIFF
--- a/recycling-code-demo/experiments/example.py
+++ b/recycling-code-demo/experiments/example.py
@@ -33,7 +33,6 @@ class CachedBertEmbeddings(CacheKeyLookup, BertEmbeddings):
 
 
 class NoOpWhenCachedBertLayer(NoOpWhenCached, BertLayer):
-    @property
     def get_cache_hit_value(self):
         return [None]
 

--- a/recycling-code-demo/experiments/example.py
+++ b/recycling-code-demo/experiments/example.py
@@ -25,7 +25,11 @@ except ImportError:
 
 
 class CachedBertEmbeddings(CacheKeyLookup, BertEmbeddings):
-    ...
+    def get_cache_arg_name_or_pos(self):
+        return "input_ids", 0
+
+    def forward(self, *args, **kwargs):
+        return super().forward(*args, **kwargs)
 
 
 class NoOpWhenCachedBertLayer(NoOpWhenCached, BertLayer):


### PR DESCRIPTION
example.py should match recycling-code-demo/src/s2re/models/bert.py.

Specifically, 

```
class CachedBertEmbeddings(CacheKeyLookup, BertEmbeddings):
    ...
```

should be

```
class CachedBertEmbeddings(CacheKeyLookup, BertEmbeddings):
    def get_cache_arg_name_or_pos(self):
        return "input_ids", 0

    def forward(self, *args, **kwargs):
        return super().forward(*args, **kwargs)
```

Without this, `CachedBertEmbeddings(config)` evaluates with `TypeError: Can't instantiate abstract class CachedBertEmbeddings with abstract method get_cache_arg_name_or_pos`